### PR TITLE
promisify extractSAPUI5 in downloader-core

### DIFF
--- a/packages/sapui5-downloader-core/src/index.js
+++ b/packages/sapui5-downloader-core/src/index.js
@@ -146,27 +146,30 @@ class Downloader {
   async extractSAPUI5(zipFile, updateProgress) {
     console.log(`Extracting SAPUI5 to ${this.directories.extract}`)
 
-    await fs.remove(this.directories.extract)
-    await fs.mkdirp(this.directories.extract)
+    return new Promise(async (resolve) => {
+      await fs.remove(this.directories.extract)
+      await fs.mkdirp(this.directories.extract)
 
-    const zip = new StreamZip({
-      file: zipFile,
-      storeEntries: true,
-    })
+      const zip = new StreamZip({
+        file: zipFile,
+        storeEntries: true,
+      })
 
-    zip.on('ready', () => {
-      zip
-        .on('extract', () => {
-          if (updateProgress) {
-            updateProgress(zip.entriesCount)
-          }
-        })
-        .extract(null, this.directories.extract, () => {
-          zip.close(() => {
-            console.log('SAPUI5 extracted')
+      zip.on('ready', () => {
+        zip
+          .on('extract', () => {
+            if (updateProgress) {
+              updateProgress(zip.entriesCount)
+            }
           })
-        })
-    })
+          .extract(null, this.directories.extract, () => {
+            zip.close(() => {
+              console.log('SAPUI5 extracted')
+              resolve();
+            })
+          })
+      })
+    });
   }
 }
 


### PR DESCRIPTION
Hi Basti,

first of all thx for this amazing tool :-)
This PR is a suggestion to promisify the Downloader.extractSAPUI5 function in the sap-ui5-downloader-core.
That allows a caller not only to have a callback for intermediate extract steps  (updateProgress callback) but also when you call it with the await statement it would actually wait until the zip file is fully extracted.

That's shouldn't touch any of the existing logic but add an additional feature to it and the "await downloader.extractSAPUI5" would actually wait until the zip is fully extracted.

Feel free to adjust my suggestion to your needs :-)

Kind regards
Thorsten